### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides search functionality for AWS Lambda Powertools documentation across multiple runtimes.
 
+<a href="https://glama.ai/mcp/servers/@serverless-dna/powertools-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@serverless-dna/powertools-mcp/badge" alt="Powertools Search Server MCP server" />
+</a>
+
 ## Claude Desktop Quickstart
 
 Follow the installation instructions please follow the [Model Context Protocol Quickstart For Claude Desktop users](https://modelcontextprotocol.io/quickstart/user#mac-os-linux).  You will need to add a section tothe MCP configuration file as follows:


### PR DESCRIPTION
This PR adds a badge for the [Powertools MCP Search Server](https://glama.ai/mcp/servers/@serverless-dna/powertools-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@serverless-dna/powertools-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@serverless-dna/powertools-mcp/badge" alt="Powertools Search Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.