### PR TITLE
feat(fecthDoc): Cache markdown files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,7 @@ import globals from 'globals';
 export default [
   {
     // Blacklisted Folders, including **/node_modules/ and .git/
-    ignores: ['dist/','build/'],
+    ignores: ['dist/','build/', 'coverage/'],
   },
   {
     // All files

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   "dependencies": {
     "@mixmark-io/domino": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.10.1",
+    "@types/cacache": "^17.0.2",
     "@types/node": "^22.14.1",
+    "cacache": "^19.0.1",
     "cheerio": "^1.0.0-rc.12",
     "html-to-markdown": "^1.0.0",
     "lunr": "^2.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.10.1
         version: 1.10.1
+      '@types/cacache':
+        specifier: ^17.0.2
+        version: 17.0.2
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
+      cacache:
+        specifier: ^19.0.1
+        version: 19.0.1
       cheerio:
         specifier: ^1.0.0-rc.12
         version: 1.0.0
@@ -827,6 +833,9 @@ packages:
 
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+
+  '@types/cacache@17.0.2':
+    resolution: {integrity: sha512-IrqHzVX2VRMDQQKa7CtKRnuoCLdRJiLW6hWU+w7i7+AaQ0Ii5bKwJxd5uRK4zBCyrHd3tG6G8zOm2LplxbSfQg==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -4769,6 +4778,10 @@ snapshots:
   '@types/babel__traverse@7.20.7':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@types/cacache@17.0.2':
+    dependencies:
+      '@types/node': 22.14.1
 
   '@types/estree@1.0.7': {}
 

--- a/src/config/cache.ts
+++ b/src/config/cache.ts
@@ -37,6 +37,15 @@ export const cacheConfig: CacheConfig = {
       factor: DEFAULT_RETRY_FACTOR,   // Exponential backoff factor
       minTimeout: DEFAULT_MIN_TIMEOUT,
       maxTimeout: DEFAULT_MAX_TIMEOUT
+    },
+    [ContentType.MARKDOWN]: {
+      path: 'markdown-cache',         // Directory for markdown content
+      maxAge: FOURTEEN_DAYS_MS,       // 14-day timeout
+      cacheMode: DEFAULT_CACHE_MODE,  // Standard HTTP cache mode
+      retries: 0,                     // No retries needed for markdown cache
+      factor: DEFAULT_RETRY_FACTOR,
+      minTimeout: DEFAULT_MIN_TIMEOUT,
+      maxTimeout: DEFAULT_MAX_TIMEOUT
     }
   }
 };

--- a/src/docFetcher.spec.ts
+++ b/src/docFetcher.spec.ts
@@ -1,7 +1,13 @@
+import { createHash } from 'crypto';
+import * as path from 'path';
+
+import cacheConfig from './config/cache';
 import { FetchService } from './services/fetch';
 import { ContentType } from './services/fetch/types';
 // Import the module after mocking
-import { fetchDocPage } from './docFetcher';
+import { clearDocCache, fetchDocPage } from './docFetcher';
+
+import * as cacache from 'cacache';
 
 // Mock the FetchService module with an inline mock function
 jest.mock('./services/fetch', () => {
@@ -13,9 +19,34 @@ jest.mock('./services/fetch', () => {
   };
 });
 
+// Mock crypto module
+jest.mock('crypto', () => {
+  return {
+    createHash: jest.fn().mockImplementation(() => ({
+      update: jest.fn().mockReturnThis(),
+      digest: jest.fn().mockReturnValue('mock-content-hash')
+    }))
+  };
+});
+
+// Mock cacache module
+jest.mock('cacache', () => {
+  return {
+    get: jest.fn(),
+    put: jest.fn().mockResolvedValue(undefined),
+    rm: {
+      all: jest.fn().mockResolvedValue(undefined)
+    }
+  };
+});
+
 // Get a reference to the mock function AFTER it's created
 const mockFetchService = FetchService as jest.MockedFunction<typeof FetchService>;
 const mockFetch = mockFetchService.mock.results[0].value.fetch;
+const mockClearCache = mockFetchService.mock.results[0].value.clearCache;
+const mockCacacheGet = cacache.get as jest.MockedFunction<typeof cacache.get>;
+const mockCacacheGetInfo = jest.fn();
+(cacache.get as any).info = mockCacacheGetInfo;
 
 // Helper function to measure memory usage
 function getMemoryUsage(): { heapUsed: number, heapTotal: number } {
@@ -143,4 +174,140 @@ afterAll(() => {
   console.log('All tests completed successfully');
   console.log('Memory usage at end of tests:', getMemoryUsage());
   console.log('===== END SUMMARY =====');
+});
+
+describe('[DocFetcher] When using markdown caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use cached markdown when available', async () => {
+    // Setup mock response for HTML fetch
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        get: jest.fn().mockImplementation((name) => {
+          if (name === 'etag') return '"mock-etag"';
+          return null;
+        })
+      },
+      text: jest.fn().mockResolvedValue('<html><body><div class="md-content" data-md-component="content"><h1>Test Page</h1><p>Test content</p></div></body></html>')
+    };
+    
+    // Setup mock for cacache.get.info and cacache.get
+    mockCacacheGetInfo.mockResolvedValueOnce({ integrity: 'sha512-test' });
+    mockCacacheGet.mockResolvedValueOnce({ 
+      data: Buffer.from('# Test Page\n\nTest content', 'utf8'),
+      metadata: null,
+      integrity: 'sha512-test'
+    });
+    
+    // Configure the fetch mock
+    mockFetch.mockResolvedValueOnce(mockResponse);
+    
+    // Call the function
+    const result = await fetchDocPage('https://docs.powertools.aws.dev/lambda/python/latest/core/logger/');
+    
+    // Verify the result
+    expect(result).toBe('# Test Page\n\nTest content');
+    
+    // Verify that the markdown was fetched from cache
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('https://docs.powertools.aws.dev/lambda/python/latest/core/logger/', expect.anything());
+    
+    // Verify that cacache was used
+    expect(mockCacacheGetInfo).toHaveBeenCalledWith(
+      path.join(cacheConfig.basePath, 'markdown-cache'),
+      'python/latest/core/logger-mock-etag'
+    );
+    expect(mockCacacheGet).toHaveBeenCalledWith(
+      path.join(cacheConfig.basePath, 'markdown-cache'),
+      'python/latest/core/logger-mock-etag'
+    );
+  });
+
+  it('should generate and cache markdown when not in cache', async () => {
+    // Setup mock response for HTML fetch
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        get: jest.fn().mockImplementation((name) => {
+          if (name === 'etag') return '"mock-etag-2"';
+          return null;
+        })
+      },
+      text: jest.fn().mockResolvedValue('<html><body><div class="md-content" data-md-component="content"><h1>Test Page</h1><p>Test content</p></div></body></html>')
+    };
+    
+    // Setup mock for cacache.get.info to throw "not found" error
+    mockCacacheGetInfo.mockRejectedValueOnce(new Error('ENOENT: no such file or directory'));
+    
+    // Configure the fetch mock
+    mockFetch.mockResolvedValueOnce(mockResponse);
+    
+    // Call the function
+    const result = await fetchDocPage('https://docs.powertools.aws.dev/lambda/python/latest/core/logger/');
+    
+    // Verify the result contains markdown
+    expect(result).toContain('# Test Page');
+    
+    // Verify that the markdown was not found in cache and then saved
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('https://docs.powertools.aws.dev/lambda/python/latest/core/logger/', expect.anything());
+    
+    // Verify that cacache was used to save the markdown
+    expect(cacache.put).toHaveBeenCalledWith(
+      path.join(cacheConfig.basePath, 'markdown-cache'),
+      'python/latest/core/logger-mock-etag-2',
+      expect.stringContaining('# Test Page')
+    );
+  });
+
+  it('should use content hash when ETag is not available', async () => {
+    // Setup mock response for HTML fetch without ETag
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        get: jest.fn().mockReturnValue(null) // No ETag
+      },
+      text: jest.fn().mockResolvedValue('<html><body><div class="md-content" data-md-component="content"><h1>Test Page</h1><p>Test content</p></div></body></html>')
+    };
+    
+    // Setup mock for cacache.get.info to throw "not found" error
+    mockCacacheGetInfo.mockRejectedValueOnce(new Error('ENOENT: no such file or directory'));
+    
+    // Configure the fetch mock
+    mockFetch.mockResolvedValueOnce(mockResponse);
+    
+    // Call the function
+    await fetchDocPage('https://docs.powertools.aws.dev/lambda/python/latest/core/logger/');
+    
+    // Verify that createHash was called to generate a content hash
+    expect(createHash).toHaveBeenCalledWith('md5');
+    
+    // Verify that the cache key includes the mock content hash
+    expect(cacache.put).toHaveBeenCalledWith(
+      path.join(cacheConfig.basePath, 'markdown-cache'),
+      'python/latest/core/logger-mock-content-hash',
+      expect.any(String)
+    );
+  });
+
+  it('should clear both HTML and markdown caches when clearDocCache is called', async () => {
+    // Call the function
+    await clearDocCache();
+    
+    // Verify that both caches were cleared
+    expect(mockClearCache).toHaveBeenCalledTimes(1);
+    expect(mockClearCache).toHaveBeenCalledWith(ContentType.WEB_PAGE);
+    expect(cacache.rm.all).toHaveBeenCalledWith(
+      path.join(cacheConfig.basePath, 'markdown-cache')
+    );
+  });
 });

--- a/src/services/fetch/cacheManager.spec.ts
+++ b/src/services/fetch/cacheManager.spec.ts
@@ -102,9 +102,8 @@ describe('[CacheManager] When managing cache files', () => {
 
       await cacheManager.clearAllCaches();
 
-      expect(fs.access).toHaveBeenCalledTimes(2);
+      expect(fs.access).toHaveBeenCalledTimes(1);
       expect(fs.access).toHaveBeenCalledWith('/tmp/cache/web-pages');
-      expect(fs.access).toHaveBeenCalledWith('/tmp/cache/search-indexes');
     });
   });
 

--- a/src/services/fetch/fetch.spec.ts
+++ b/src/services/fetch/fetch.spec.ts
@@ -97,14 +97,14 @@ describe('[FetchService] When making HTTP requests', () => {
       const mockSearchIndexFetch = jest.fn().mockResolvedValue('search-index-response');
       
       mockFetchInstances.set(ContentType.WEB_PAGE, mockWebPageFetch);
-      mockFetchInstances.set(ContentType.SEARCH_INDEX, mockSearchIndexFetch);
+      mockFetchInstances.set(ContentType.MARKDOWN, mockSearchIndexFetch);
       
       // Set the mock fetch instances
       (fetchService as any).fetchInstances = mockFetchInstances;
 
-      await fetchService.fetch('https://example.com/search?q=test');
+      await fetchService.fetch('https://markdown.local/test');
       
-      expect(mockSearchIndexFetch).toHaveBeenCalledWith('https://example.com/search?q=test', expect.objectContaining({
+      expect(mockSearchIndexFetch).toHaveBeenCalledWith('https://markdown.local/test', expect.objectContaining({
         headers: {}
       }));
       expect(mockWebPageFetch).not.toHaveBeenCalled();

--- a/src/services/fetch/fetch.ts
+++ b/src/services/fetch/fetch.ts
@@ -105,10 +105,8 @@ export class FetchService {
     if (explicitType) return explicitType;
     
     const urlString = url.toString();
-    if (urlString.includes('/api/index') || urlString.includes('/search')) {
-      return ContentType.SEARCH_INDEX;
-    } else if (urlString.includes('/api/')) {
-      return ContentType.API_DATA;
+    if (urlString.includes('markdown.local')) {
+      return ContentType.MARKDOWN;
     }
     return ContentType.WEB_PAGE;
   }

--- a/src/services/fetch/types.ts
+++ b/src/services/fetch/types.ts
@@ -3,8 +3,7 @@
  */
 export enum ContentType {
     WEB_PAGE = 'web-page',
-    SEARCH_INDEX = 'search-index',
-    API_DATA = 'api-data'
+    MARKDOWN = 'markdown'
 }
   
 /**


### PR DESCRIPTION
## Description

- Cache markdown processed files during fetch. 
- Use Cacache for disk caching of stripped HTML files from the web.
- For a cache hit on web fetch, check if the MD is cached and use that (not processing again)
- Add error logging for cache HIT/MISS for fetch and MD (log tracing)

Fixes #10 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested through unit tests and direct plugin to Claude Desktop

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
