### PR TITLE
fix(action): resolve action lint issue in version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'chore(release)')"
+    if: '!contains(github.event.head_commit.message, ''skip ci'') && !contains(github.event.head_commit.message, ''chore(release)'')'
     
     steps:
       - name: Checkout


### PR DESCRIPTION
## PR Comment: Fix for GitHub Actions Workflow Syntax

### Changes Overview
This PR fixes a linting issue in the version-bump.yml GitHub Actions workflow file by properly formatting string quotes in the conditional statement.

### Details
- Changed the quote style in the workflow's conditional statement from double quotes with single quotes inside to single quotes with escaped single quotes inside
- Before: `if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'chore(release)')"`
- After: `if: '!contains(github.event.head_commit.message, ''skip ci'') && !contains(github.event.head_commit.message, ''chore(release)'')'`

### Why This Matters
This change ensures proper YAML syntax in GitHub Actions workflows, preventing potential parsing errors and ensuring the workflow runs as expected. The fix follows GitHub Actions best practices for handling nested quotes in conditional statements.

### Testing
The workflow has been validated with GitHub's YAML linter to ensure proper syntax.
